### PR TITLE
Make container small by build in one and then copying

### DIFF
--- a/shared/placement-uwsgi.ini
+++ b/shared/placement-uwsgi.ini
@@ -1,9 +1,9 @@
 [uwsgi]
-plugins = python3
-wsgi-file = /usr/local/bin/placement-api
-# If we're proxying in a /placement clean up
+wsgi-file = /app/bin/placement-api
+# If we're proxying in a /placement, clean up
 route = ^/placement setscriptname:/placement
 route = ^/placement fixpathinfo:
+venv = /app
 
 processes = 2
 threads = 10

--- a/shared/startup.sh
+++ b/shared/startup.sh
@@ -8,7 +8,7 @@ DB_SYNC=${DB_SYNC:-False}
 OS_API__AUTH_STRATEGY=${OS_API__AUTH_STRATEGY:?OS_API__AUTH_STRATEGY required}
 
 # establish the database, only if we've been asked to do so.
-[ "$DB_SYNC" = "True" ] && /usr/local/bin/placement-manage db sync
+[ "$DB_SYNC" = "True" ] && /app/bin/placement-manage db sync
 
 # run the web server
-/usr/local/bin/uwsgi --ini /placement-uwsgi.ini
+/app/bin/uwsgi --ini /placement-uwsgi.ini


### PR DESCRIPTION
We git and pip install on one container, along with all the dev
libraries that are required. That relevant python goes into a
venv. That venv is then copied to a clean container where only
the necessary shared libraries are present (along with python).